### PR TITLE
Support removeDocument from synchronizer and isDocSubscribedTo

### DIFF
--- a/packages/automerge-repo/src/RemoteHeadsSubscriptions.ts
+++ b/packages/automerge-repo/src/RemoteHeadsSubscriptions.ts
@@ -325,6 +325,13 @@ export class RemoteHeadsSubscriptions extends EventEmitter<RemoteHeadsSubscripti
     }
   }
 
+  isDocSubscribedTo(documentId: DocumentId) {
+    for (const [peerId, subscribedDocs] of this.#subscribedDocsByPeer) {
+      if (subscribedDocs.has(documentId)) return true
+    }
+    return false
+  }
+
   #isPeerSubscribedToDoc(peerId: PeerId, documentId: DocumentId) {
     const subscribedDocs = this.#subscribedDocsByPeer.get(peerId)
     return subscribedDocs && subscribedDocs.has(documentId)

--- a/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
@@ -116,10 +116,9 @@ export class CollectionSynchronizer extends Synchronizer {
     })
   }
 
-  // TODO: implement this
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   removeDocument(documentId: DocumentId) {
-    throw new Error("not implemented")
+    delete this.#docSynchronizers[documentId]
+    delete this.#docSetUp[documentId]
   }
 
   /** Adds a peer and maybe starts synchronizing with them */

--- a/packages/automerge-repo/test/CollectionSynchronizer.test.ts
+++ b/packages/automerge-repo/test/CollectionSynchronizer.test.ts
@@ -75,4 +75,20 @@ describe("CollectionSynchronizer", () => {
 
       setTimeout(done)
     }))
+
+  it("should not synchronize a document removed from synchronizer", () =>
+    new Promise<void>((done, reject) => {
+      const handle = repo.create()
+
+      synchronizer.addDocument(handle.documentId)
+      synchronizer.removeDocument(handle.documentId)
+
+      synchronizer.once("message", () => {
+        reject(new Error("Should not have sent a message"))
+      })
+
+      synchronizer.addPeer("peer2" as PeerId)
+
+      setTimeout(done)
+    }))
 })

--- a/packages/automerge-repo/test/RemoteHeadsSubscriptions.test.ts
+++ b/packages/automerge-repo/test/RemoteHeadsSubscriptions.test.ts
@@ -175,7 +175,7 @@ describe("RepoHeadsSubscriptions", () => {
       event: "change-remote-subs",
     })
 
-    // unsubsscribe from storage B
+    // unsubscribe from storage B
     remoteHeadsSubscriptions.unsubscribeFromRemotes([storageB])
 
     // should forward unsubscribe to generous peer
@@ -223,8 +223,12 @@ describe("RepoHeadsSubscriptions", () => {
       emitter: remoteHeadsSubscriptions,
       event: "notify-remote-heads",
     })
+    assert(!remoteHeadsSubscriptions.isDocSubscribedTo(docA))
+    assert(!remoteHeadsSubscriptions.isDocSubscribedTo(docC))
     remoteHeadsSubscriptions.subscribePeerToDoc(peerC, docA)
     remoteHeadsSubscriptions.subscribePeerToDoc(peerC, docC)
+    assert(remoteHeadsSubscriptions.isDocSubscribedTo(docA))
+    assert(remoteHeadsSubscriptions.isDocSubscribedTo(docC))
 
     // change message for docA in storageB
     remoteHeadsSubscriptions.handleRemoteHeads(docAHeadsChangedForStorageB)
@@ -248,7 +252,7 @@ describe("RepoHeadsSubscriptions", () => {
 
     // unsubscribe peer C
     remoteHeadsSubscriptions.handleControlMessage(unsubscribePeerCFromStorageB)
-    const messagesAfteUnsubscribePromise = collectMessages({
+    const messagesAfterUnsubscribePromise = collectMessages({
       emitter: remoteHeadsSubscriptions,
       event: "notify-remote-heads",
     })
@@ -256,8 +260,8 @@ describe("RepoHeadsSubscriptions", () => {
     // heads of docB for storageB change
     remoteHeadsSubscriptions.handleRemoteHeads(docBHeadsChangedForStorageB)
 
-    // expect not to be be notified
-    messages = await messagesAfteUnsubscribePromise
+    // expect not to be notified
+    messages = await messagesAfterUnsubscribePromise
     assert.strictEqual(messages.length, 0)
   })
 


### PR DESCRIPTION
**Summary:**
Add support for `removeDocument` from synchronizer so that we can start evicting doc handles from Repo handleCache.
Add support for `isDocSubscribedTo` so that we only evict doc handles that don't have any subscribed peers.

**Issue:**
https://github.com/automerge/automerge-repo/issues/330

**Background:**
After creating enough documents in a repo, out of memory errors will cause a synch server to crash because memory isn't being freed. Repo holds references to each DocHandle in handleCache and each DocHandle holds a reference to the automerge doc.

**Proposed solution:**
https://github.com/georgewsu/automerge-repo/tree/gsu/cache-eviction-test2 has code for an initial implementation of cache eviction and releasing document reference so that memory can be freed. I've tested this with a sync server running locally.

**Part 1:**
https://github.com/automerge/automerge-repo/pull/365

**Part 2:**
This PR only covers introducing `removeDocument` and `isDocSubscribedTo` so that in the next PR we can evict doc handles from Repo handleCache.
