### PR TITLE
Remove DocHandle from docSynchronizers

### DIFF
--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -84,8 +84,7 @@ export class Repo extends EventEmitter<RepoEvents> {
     this.sharePolicy = sharePolicy ?? this.sharePolicy
 
     this.on("delete-document", ({ documentId }) => {
-      // TODO Pass the delete on to the network
-      // synchronizer.removeDocument(documentId)
+      this.synchronizer.removeDocument(documentId)
 
       if (storageSubsystem) {
         storageSubsystem.removeDoc(documentId).catch(err => {
@@ -570,8 +569,7 @@ export class Repo extends EventEmitter<RepoEvents> {
         )
       }
       delete this.#handleCache[documentId]
-      // TODO: remove document from synchronizer when removeDocument is implemented
-      // this.synchronizer.removeDocument(documentId)
+      this.synchronizer.removeDocument(documentId)
     } else {
       this.#log(
         `WARN: removeFromCache called but doc undefined for documentId: ${documentId}`

--- a/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
@@ -117,10 +117,9 @@ export class CollectionSynchronizer extends Synchronizer {
     })
   }
 
-  // TODO: implement this
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   removeDocument(documentId: DocumentId) {
-    throw new Error("not implemented")
+    delete this.docSynchronizers[documentId];
+    delete this.#docSetUp[documentId];
   }
 
   /** Adds a peer and maybe starts synchronizing with them */


### PR DESCRIPTION
Remove DocHandle from docSynchronizers, so that memory usage can be freed.
